### PR TITLE
Fix parseProjects fallback images

### DIFF
--- a/lib/content.ts
+++ b/lib/content.ts
@@ -70,7 +70,9 @@ export function parseProjects(pages: Page[]): ProjectData[] {
 
     // Get project images from individual project page
     const projectImages =
-      projectPage?.images || [thumbnailImage].filter(Boolean);
+      projectPage && projectPage.images.length > 0
+        ? projectPage.images
+        : [thumbnailImage].filter(Boolean);
 
     // Extract description from project page
     const description = projectPage?.content[0]?.content


### PR DESCRIPTION
## Summary
- ensure `parseProjects` always has at least one image by checking for empty arrays

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*